### PR TITLE
Fix hardcoded outptu directory

### DIFF
--- a/BERT_NER.py
+++ b/BERT_NER.py
@@ -210,7 +210,7 @@ def convert_single_example(ex_index, example, label_list, max_seq_length, tokeni
     label_map = {}
     for (i, label) in enumerate(label_list,1):
         label_map[label] = i
-    with open('./output/label2id.pkl','wb') as w:
+    with open(os.path.join(FLAGS.output_dir, 'label2id.pkl'),'wb') as w:
         pickle.dump(label_map,w)
     textlist = example.text.split(' ')
     labellist = example.label.split(' ')


### PR DESCRIPTION
When pickling and dumping the labels map, the output directory is hardcoded and an error is thrown if not existent.

It is better to take the output dir from FLAGS.